### PR TITLE
Implement listrole command

### DIFF
--- a/Commands/listRole.js
+++ b/Commands/listRole.js
@@ -1,0 +1,37 @@
+const { EmbedBuilder } = require('discord.js');
+
+module.exports = {
+    name: "listrole",
+    description: "Affiche la liste des membres possédant un rôle.",
+    permission: "Aucune",
+    dm: false,
+    options: [
+        {
+            type: "ROLE",
+            name: "role",
+            description: "Rôle à afficher",
+            required: true,
+        }
+    ],
+    async run(bot, interaction) {
+        const role = interaction.options.getRole('role');
+
+        await interaction.deferReply({ ephemeral: true });
+        await interaction.guild.members.fetch();
+
+        const members = role.members.map(m => m.displayName || m.user.username);
+
+        const embed = new EmbedBuilder()
+            .setTitle(`Rôle : ${role.name}`)
+            .addFields(
+                { name: 'Nom du rôle', value: role.name, inline: true },
+                { name: 'Nombre de membres', value: `${members.length}`, inline: true },
+                { name: 'Pseudo des membres', value: members.length > 0 ? members.join('\n') : 'Aucun membre.' },
+                { name: 'Date du rôle', value: `<t:${Math.floor(role.createdTimestamp / 1000)}:F>` }
+            )
+            .setColor(role.color || '#0099ff')
+            .setTimestamp();
+
+        await interaction.editReply({ embeds: [embed] });
+    }
+};

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Chantal est un bot Discord avancé conçu pour animer et gérer une communauté 
 - 📌 **Citations** : Système de sauvegarde et suppression des meilleures citations des membres.
 - 📜 **Best-of mensuel** : Génération automatique d’un best-of des citations chaque mois.
 - 🔄 **Mise à jour des rôles** : Synchronisation automatique des rôles Discord en fonction des données Firestore.
+- 📋 **Liste des membres par rôle** : `/listrole` affiche les membres possédant un rôle, leur nombre et la date de création du rôle.
 
 ### 🔹 Intégrations et API
 - 📰 **Flux RSS Lodestone** : Surveillance des news FFXIV et publication automatique sur Discord.
@@ -69,6 +70,7 @@ commands: {
   quote: { enabled: true },
   suggestion: { enabled: true },
   update: { enabled: true },
+  listrole: { enabled: true },
 }
 
 Mettez `enabled` à `false` pour bloquer une commande et utilisez `message` pour

--- a/settings-example.js
+++ b/settings-example.js
@@ -55,6 +55,7 @@ module.exports = {
     quote: { enabled: true },
     suggestion: { enabled: true },
     update: { enabled: true },
+    listrole: { enabled: true },
   },
 
   // Activer ou désactiver certaines fonctionnalités du bot


### PR DESCRIPTION
## Summary
- add new `/listrole` command
- allow enabling it through settings
- document new command and setting
- remove live updates and just show role info in an embed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859757927488323baee7b65ece918a6