### PR TITLE
Ajout du suivi RSS Twitter

### DIFF
--- a/Helpers/rssHandler.js
+++ b/Helpers/rssHandler.js
@@ -166,4 +166,4 @@ async function checkRSS(bot, rssUrl) {
     }
 }
 
-module.exports = { checkRSS };
+module.exports = { checkRSS, isDuplicateMessage, convertToFrenchTime };

--- a/Helpers/twitterFeed.js
+++ b/Helpers/twitterFeed.js
@@ -1,0 +1,65 @@
+const RSSParser = require('rss-parser');
+const parser = new RSSParser();
+const { dateFormatLog } = require('./logTools');
+const { isDuplicateMessage, convertToFrenchTime } = require('./rssHandler');
+
+/**
+ * Vérifie et publie les tweets correspondant à un filtre depuis un compte Twitter via Nitter.
+ * @param {Client} bot - Instance du bot Discord.
+ * @param {string} username - Nom d'utilisateur Twitter.
+ * @param {string} titleFilter - Texte devant être présent dans le titre du tweet.
+ */
+async function checkTwitterFeed(bot, username, titleFilter) {
+  const rssUrl = `https://nitter.net/${username}/rss`;
+  try {
+    const feed = await parser.parseURL(rssUrl);
+    const now = Date.now();
+
+    for (const item of feed.items) {
+      if (!item.title || !item.title.toLowerCase().includes(titleFilter.toLowerCase())) {
+        continue;
+      }
+
+      const pubDate = new Date(item.pubDate || item.isoDate).getTime();
+      if (isNaN(pubDate) || now - pubDate > 5 * 60 * 60 * 1000) {
+        continue;
+      }
+
+      const idMatch = item.link.match(/status\/(\d+)/);
+      const tweetUrl = idMatch ? `https://x.com/${username}/status/${idMatch[1]}` : item.link;
+
+      const frenchTime = convertToFrenchTime(pubDate);
+      const embed = {
+        title: item.title,
+        url: tweetUrl,
+        footer: {
+          text: `Twitter • ${frenchTime}`,
+          icon_url: 'https://abs.twimg.com/icons/apple-touch-icon-192x192.png'
+        }
+      };
+
+      const channelId = bot.settings?.ids?.rssChannel;
+      if (!channelId) {
+        console.warn(await dateFormatLog() + "Aucun canal RSS défini dans les paramètres.");
+        return;
+      }
+      const channel = bot.channels.cache.get(channelId);
+      if (!channel) {
+        console.error(await dateFormatLog() + `Le canal avec l'ID ${channelId} n'existe pas.`);
+        return;
+      }
+
+      if (await isDuplicateMessage(channel, item.title)) {
+        console.log(await dateFormatLog() + `Tweet déjà publié, passage : ${item.title}`);
+        continue;
+      }
+
+      await channel.send({ embeds: [embed] });
+      console.log(await dateFormatLog() + `Publication Twitter : ${item.title}`);
+    }
+  } catch (error) {
+    console.error('Erreur lors de la vérification du flux Twitter :', error);
+  }
+}
+
+module.exports = { checkTwitterFeed };

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Chantal est un bot Discord avancé conçu pour animer et gérer une communauté 
 
 ### 🔹 Intégrations et API
 - 📰 **Flux RSS Lodestone** : Surveillance des news FFXIV et publication automatique sur Discord.
+- 🐦 **Suivi Twitter ciblé** : Récupération de tweets spécifiques via Nitter pour relayer les Fashion Report. Configurez les comptes et mots-clés dans `twitterFeeds`.
 
 ### 🔹 Utilitaires
 - 🛠️ **Commandes personnalisées** : `/help`, `/quote`, `/kaazino`, etc.
@@ -82,6 +83,7 @@ fonctionnalités du bot :
 
 features: {
   rssFeed: true,
+  twitterFeed: true,
   monthlyBestOf: true,
   verifyWord: true,
   quoteSystem: true,
@@ -91,6 +93,15 @@ features: {
 }
 
 Passez la valeur à `false` pour désactiver l'une de ces fonctionnalités.
+
+La section `twitterFeeds` vous permet de définir les comptes et mots-clés à surveiller via Nitter :
+
+```js
+twitterFeeds: [
+  { username: "KaiyokoStar", filter: "Fashion Report Week" },
+  // { username: "Machin", filter: "Fashion" }
+]
+```
 
 ### Le démarrer
 node bot.js

--- a/bot.js
+++ b/bot.js
@@ -77,6 +77,7 @@ loadCommands(bot);
 loadEvents(bot);
 
 const { checkRSS } = require('./Helpers/rssHandler');
+const { checkTwitterFeed } = require('./Helpers/twitterFeed');
 const RSS_FEEDS = [
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/news.xml' },
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/topics.xml' }
@@ -111,6 +112,16 @@ bot.on('ready', () => {
   setInterval(() => {
     if (bot.settings.features?.rssFeed !== false) {
       RSS_FEEDS.forEach(feed => checkRSS(bot, feed.url));
+    }
+    if (bot.settings.features?.twitterFeed !== false) {
+      const twitterFeeds = bot.settings.twitterFeeds;
+      if (Array.isArray(twitterFeeds)) {
+        twitterFeeds.forEach(feed => {
+          if (feed.username) {
+            checkTwitterFeed(bot, feed.username, feed.filter || '');
+          }
+        });
+      }
     }
     if (bot.settings.features?.monthlyBestOf !== false) {
       createMonthlyBestOf(bot);

--- a/settings-example.js
+++ b/settings-example.js
@@ -61,11 +61,18 @@ module.exports = {
   // Activer ou désactiver certaines fonctionnalités du bot
   features: {
     rssFeed: true,
+    twitterFeed: true,
     monthlyBestOf: true,
     verifyWord: true,
     quoteSystem: true,
     welcomeMessages: true,
     goodbyeMessages: true,
     keepAlive: true,
-  }
+  },
+
+  // Liste des comptes Twitter à surveiller via Nitter
+  twitterFeeds: [
+    { username: "KaiyokoStar", filter: "Fashion Report Week" },
+    // { username: "Machin", filter: "Fashion" }
+  ]
 };


### PR DESCRIPTION
## Résumé
- support du filtrage RSS pour les tweets via Nitter
- intégration configurée dans `bot.js` à partir des paramètres `twitterFeeds`
- ajout du paramètre `twitterFeed` et de la liste `twitterFeeds` dans `settings-example.js`
- documentation mise à jour pour expliquer la configuration du suivi Twitter

## Tests
- `npm test` *(échec : Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a89fbdc148323b82c650c3ea00de4