### PR TITLE
Fix Twitter RSS via proxy

### DIFF
--- a/Helpers/twitterFeed.js
+++ b/Helpers/twitterFeed.js
@@ -1,5 +1,9 @@
 const RSSParser = require('rss-parser');
-const parser = new RSSParser();
+const { HttpsProxyAgent } = require('https-proxy-agent');
+
+const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+const parserOptions = proxy ? { requestOptions: { agent: new HttpsProxyAgent(proxy) } } : {};
+const parser = new RSSParser(parserOptions);
 const { dateFormatLog } = require('./logTools');
 const { isDuplicateMessage, convertToFrenchTime } = require('./rssHandler');
 

--- a/Loader/loadSlashCommands.js
+++ b/Loader/loadSlashCommands.js
@@ -32,11 +32,15 @@ module.exports = async bot => {
                  else if(command.options[i].type === "STRING") {
                     slashCommand[`add${command.options[i].type.charAt(0).toUpperCase()
                         + command.options[i].type.slice(1).toLowerCase()}Option`]
-                    (optionBuilder => 
-                    optionBuilder.setName(command.options[i].name)
-                    .setDescription(command.options[i].description)
-                    .setAutocomplete(command.options[i].autocomplete)
-                    .setRequired(command.options[i].required)) 
+                    (optionBuilder => {
+                        optionBuilder.setName(command.options[i].name)
+                            .setDescription(command.options[i].description)
+                            .setRequired(command.options[i].required)
+                        if (typeof command.options[i].autocomplete === 'boolean') {
+                            optionBuilder.setAutocomplete(command.options[i].autocomplete)
+                        }
+                        return optionBuilder
+                    })
                 }
                 else{
                 // Put in the format capital letter for first caracter. Then put name, description and required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "firebase": "^10.12.2",
         "firebase-admin": "^12.1.1",
         "fs-extra": "^11.2.0",
+        "https-proxy-agent": "^7.0.6",
         "module-alias": "^2.2.3",
         "puppeteer": "^22.12.0",
         "requests": "^0.3.0",
@@ -1317,36 +1318,13 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3290,11 +3268,12 @@
       "optional": true
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "firebase": "^10.12.2",
     "firebase-admin": "^12.1.1",
     "fs-extra": "^11.2.0",
+    "https-proxy-agent": "^7.0.6",
     "module-alias": "^2.2.3",
     "puppeteer": "^22.12.0",
     "requests": "^0.3.0",


### PR DESCRIPTION
## Summary
- use `https-proxy-agent` to respect HTTPS proxy for Twitter RSS parsing
- add `https-proxy-agent` dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aa3d13db083238130045cd01af138