### PR TITLE
Supprime node-fetch non utilisé

### DIFF
--- a/Helpers/redditFashionRSS.js
+++ b/Helpers/redditFashionRSS.js
@@ -1,5 +1,4 @@
 const RSSParser = require('rss-parser');
-const fetch = require('node-fetch');
 const { dateFormatLog } = require('./logTools');
 
 const parser = new RSSParser({

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "firebase-admin": "^12.1.1",
         "fs-extra": "^11.2.0",
         "module-alias": "^2.2.3",
-        "node-fetch": "^2.7.0",
         "puppeteer": "^22.12.0",
         "requests": "^0.3.0",
         "rss-parser": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "firebase-admin": "^12.1.1",
     "fs-extra": "^11.2.0",
     "module-alias": "^2.2.3",
-    "node-fetch": "^2.7.0",
     "puppeteer": "^22.12.0",
     "requests": "^0.3.0",
     "rss-parser": "^3.13.0",


### PR DESCRIPTION
## Résumé
- retire l'import `node-fetch` de `Helpers/redditFashionRSS.js`
- enlève la dépendance `node-fetch` du `package.json`
- met à jour `package-lock.json` en conséquence

## Tests
- `npm test` *(échoue : aucun script défini)*

------
https://chatgpt.com/codex/tasks/task_e_685acb34ea0883239cb1df81936987f5