### PR TITLE
Filtre les posts Reddit trop anciens

### DIFF
--- a/Helpers/redditFashionRSS.js
+++ b/Helpers/redditFashionRSS.js
@@ -48,6 +48,11 @@ async function checkRedditFashion(bot, rssUrl) {
     try {
         const feed = await parser.parseURL(rssUrl);
         for (const item of feed.items) {
+            const pubDate = new Date(item.pubDate || item.isoDate).getTime();
+            if (!pubDate || Date.now() - pubDate > 7 * 24 * 60 * 60 * 1000) {
+                continue;
+            }
+
             const author = item.author || item.creator || '';
             const title = item.title || '';
             if (!author.includes('Gottesstrafe') || !title.includes('Fashion Report - Full Details - For Week of')) {

--- a/bot.js
+++ b/bot.js
@@ -82,7 +82,7 @@ const RSS_FEEDS = [
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/news.xml' },
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/topics.xml' }
 ];
-const REDDIT_FASHION_RSS = 'https://www.reddit.com/r/ffxiv/search.rss?restrict_sr=on&sort=new&q=author%3AGottesstrafe+Fashion+Report+-+Full+Details+-+For+Week+of';
+const REDDIT_FASHION_RSS = 'https://www.reddit.com/r/ffxiv/search.rss?restrict_sr=on&sort=new&q=author%3AGottesstrafe+Fashion+Report+-+Full+Details+-+For+Week+of&t=week';
 const { createMonthlyBestOf } = require('@helpers/createMonthlyBestOf');
 
 bot.on('ready', () => {


### PR DESCRIPTION
## Résumé
- ajoute un filtre de date aux posts RSS Reddit pour ignorer ceux de plus de 7 jours
- ajoute le paramètre `t=week` à l'URL du flux Reddit

## Tests
- `npm test` *(échoue : script "test" manquant)*

------
https://chatgpt.com/codex/tasks/task_e_685ace9c50448323946f271a92cea8c1