### PR TITLE
Met à jour la configuration d'intervalle Reddit

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ features: {
 
 Passez la valeur à `false` pour désactiver l'une de ces fonctionnalités.
 
-Une section `intervals` permet également de personnaliser certaines fréquences de vérification :
+Une section `intervals` (exprimée en **heures**) permet également de personnaliser certaines fréquences de vérification :
 
 ```js
 intervals: {
-  redditFashionRSS: 24 * 60 * 60 * 1000, // vérifie le flux Fashion Report toutes les 24h
+  redditFashionRSS: 24, // vérifie le flux Fashion Report toutes les 24h
 }
 ```
 

--- a/bot.js
+++ b/bot.js
@@ -80,7 +80,7 @@ const { checkRSS } = require('./Helpers/rssHandler');
 const { checkRedditFashion } = require('./Helpers/redditFashionRSS');
 const RSS_CHECK_INTERVAL = 15 * 60 * 1000; // 15 minutes
 const REDDIT_CHECK_INTERVAL =
-  bot.settings.intervals?.redditFashionRSS ?? 24 * 60 * 60 * 1000; // 24 heures par défaut
+  (bot.settings.intervals?.redditFashionRSS ?? 24) * 60 * 60 * 1000; // 24 h par défaut
 const RSS_FEEDS = [
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/news.xml' },
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/topics.xml' }

--- a/settings-example.js
+++ b/settings-example.js
@@ -73,9 +73,9 @@ module.exports = {
     keepAlive: true,
   },
 
-  // Intervalles de vérification (en millisecondes)
+  // Intervalles de vérification (en heures)
   intervals: {
-    // Intervalle pour le flux Fashion Report de Reddit (ex. 24h)
-    redditFashionRSS: 24 * 60 * 60 * 1000,
+    // Intervalle pour le flux Fashion Report de Reddit (ex. 24 pour 24h)
+    redditFashionRSS: 24,
   }
 };


### PR DESCRIPTION
## Résumé
- intervals dans `settings-example.js` sont maintenant indiqués en **heures**
- README modifié pour préciser cette nouvelle syntaxe
- conversion en millisecondes dans `bot.js`

## Tests
- `npm test` *(échoue : script "test" manquant)*

------
https://chatgpt.com/codex/tasks/task_e_685b360576cc8323a77173ca4c090c65