### PR TITLE
Amélioration de l'extraction d'image depuis Reddit

### DIFF
--- a/Helpers/redditFashion.js
+++ b/Helpers/redditFashion.js
@@ -1,6 +1,46 @@
 const RSSParser = require('rss-parser');
-const parser = new RSSParser();
+const { EmbedBuilder } = require('discord.js');
+const parser = new RSSParser({
+    headers: { 'User-Agent': 'Mozilla/5.0 (OtterBot RSS Reader)' },
+    customFields: { item: ['media:thumbnail', 'media:content'] }
+});
 const { dateFormatLog } = require('./logTools');
+
+function decodeHtmlEntities(str) {
+    return str
+        ? str
+              .replace(/&amp;/g, '&')
+              .replace(/&lt;/g, '<')
+              .replace(/&gt;/g, '>')
+              .replace(/&quot;/g, '"')
+              .replace(/&#39;/g, "'")
+        : str;
+}
+
+function cleanImageUrl(url) {
+    return url ? decodeHtmlEntities(url) : url;
+}
+
+function extractImage(content) {
+    const imgMatch = content && content.match(/<img[^>]+src="([^"]+)"/);
+    return imgMatch ? decodeHtmlEntities(imgMatch[1]) : null;
+}
+
+function getOriginalImage(content, thumbnailUrl) {
+    const linkMatch =
+        content &&
+        content.match(/<a[^>]+href="(https:\/\/(?:i\.redd\.it|i\.imgur\.com)[^"]+)"/);
+    if (linkMatch) {
+        return decodeHtmlEntities(linkMatch[1]);
+    }
+    if (thumbnailUrl && thumbnailUrl.includes('preview.redd.it')) {
+        let url = thumbnailUrl.split('?')[0];
+        url = url.replace('external-preview.redd.it', 'i.redd.it');
+        url = url.replace('preview.redd.it', 'i.redd.it');
+        return cleanImageUrl(url);
+    }
+    return cleanImageUrl(thumbnailUrl);
+}
 
 async function isDuplicateMessage(channel, title) {
     try {
@@ -47,11 +87,27 @@ async function checkRedditFashion(bot, rssUrl, channelId) {
                 continue;
             }
 
-            const embed = {
-                title: item.title || 'Reddit Fashion',
-                url: item.link,
-                footer: { text: `Reddit • ${new Date(pubDate).toLocaleString('fr-FR')}` },
-            };
+            const htmlContent = item['content:encoded'] || item.content;
+            const mediaContent =
+                item['media:content']?.$.url ||
+                item['media:content']?.url ||
+                item['media:thumbnail']?.$.url ||
+                item['media:thumbnail'];
+            const imageUrl = getOriginalImage(htmlContent, mediaContent);
+            if (imageUrl) {
+                console.log(await dateFormatLog() + `Image détectée : ${imageUrl}`);
+            } else {
+                console.log(await dateFormatLog() + `Aucune image trouvée pour : ${item.link}`);
+            }
+
+            const embed = new EmbedBuilder()
+                .setTitle(item.title || 'Reddit Fashion')
+                .setURL(item.link)
+                .setFooter({ text: `Reddit • ${new Date(pubDate).toLocaleString('fr-FR')}` });
+
+            if (imageUrl) {
+                embed.setImage(imageUrl);
+            }
 
             await channel.send({ embeds: [embed] });
             console.log(await dateFormatLog() + `Publication d'un post Reddit Fashion : ${item.title}`);


### PR DESCRIPTION
## Résumé
- mise à jour des utilitaires pour récupérer la miniature Reddit
- utilisation de `media:content` ou `media:thumbnail` pour reconstruire l'URL de l'image
- ajout de l'image dans l'embed envoyé sur Discord

## Test
- `node -e "require('./Helpers/redditFashion.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_685c411fe2188323b8aefaa1fab8c073