### PR TITLE
Paramètre pour limite d'ancienneté RSS

### DIFF
--- a/Helpers/redditFashion.js
+++ b/Helpers/redditFashion.js
@@ -71,6 +71,7 @@ async function checkRedditFashion(bot, rssUrl, channelId) {
         }
 
         const now = Date.now();
+        const freshnessHours = bot.settings.rssFreshnessHours || 5;
 
         for (const item of feed.items) {
             const pubDate = new Date(item.pubDate || item.isoDate).getTime();
@@ -79,7 +80,7 @@ async function checkRedditFashion(bot, rssUrl, channelId) {
                 continue;
             }
 
-            if (now - pubDate > 5 * 60 * 60 * 1000) {
+            if (now - pubDate > freshnessHours * 60 * 60 * 1000) {
                 continue;
             }
 

--- a/Helpers/rssHandler.js
+++ b/Helpers/rssHandler.js
@@ -76,6 +76,7 @@ async function checkRSS(bot, rssUrl) {
 
         // Récupérer l'heure actuelle
         const now = Date.now();
+        const freshnessHours = bot.settings.rssFreshnessHours || 5;
 
         // Lire les items du flux
         for (const item of feed.items) {
@@ -88,7 +89,7 @@ async function checkRSS(bot, rssUrl) {
 
             const timeDiff = now - pubDate; // Différence en millisecondes
 
-            if (timeDiff > 5 * 60 * 60 * 1000) {
+            if (timeDiff > freshnessHours * 60 * 60 * 1000) {
                 // Ignorer les articles plus anciens que 5 heure
                 continue;
             }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Certains délais peuvent être ajustés dans `settings.js` :
 
 ```js
 redditFashionInterval: 60 // Vérifie le flux Reddit Fashion toutes les 60 minutes
+rssFreshnessHours: 5     // Ignore les posts RSS plus vieux que 5 heures
 ```
 
 ### Désactiver des commandes

--- a/settings-dev.js
+++ b/settings-dev.js
@@ -14,6 +14,9 @@ module.exports = {
   // Intervalle de vérification du flux Reddit Fashion (en minutes)
   redditFashionInterval: 60,
 
+  // Durée maximale d'ancienneté des posts RSS (en heures)
+  rssFreshnessHours: 5,
+
   ids: {
     // Canal de bienvenue
     welcomeChannel: '653689680906420238',

--- a/settings.js
+++ b/settings.js
@@ -14,6 +14,9 @@ module.exports = {
   // Intervalle de vérification du flux Reddit Fashion (en minutes)
   redditFashionInterval: 60,
 
+  // Durée maximale d'ancienneté des posts RSS (en heures)
+  rssFreshnessHours: 5,
+
   ids: {
     // Canal où sont envoyés les messages de bienvenue
     welcomeChannel: '675910340936204288',


### PR DESCRIPTION
## Résumé
- ajout d'une option `rssFreshnessHours` dans `settings.js` et `settings-dev.js`
- utilisation de cette option dans les helpers RSS
- documentation de la nouvelle variable dans le README

## Test
- *Aucun test automatisé disponible*

------
https://chatgpt.com/codex/tasks/task_e_685cf616bc94832387d40c46fc905cac