### PR TITLE
Ajout de la commande /listerole

### DIFF
--- a/Commands/listerole.js
+++ b/Commands/listerole.js
@@ -1,0 +1,42 @@
+const { EmbedBuilder } = require('discord.js');
+const settings = require('../settings.json');
+
+module.exports = {
+    name: "listerole",
+    description: "Affiche la liste des membres possédant un rôle.",
+    permission: "Aucune",
+    dm: false,
+    options: [
+        {
+            type: "ROLE",
+            name: "role",
+            description: "Rôle à afficher",
+            required: true,
+        }
+    ],
+    async run(bot, interaction) {
+        if (!settings.commands?.listerole) {
+            return interaction.reply({ content: 'Cette fonctionnalité est désactivée.', ephemeral: true });
+        }
+
+        const role = interaction.options.getRole('role');
+
+        await interaction.deferReply({ ephemeral: true });
+        await interaction.guild.members.fetch();
+
+        const members = role.members.map(m => `\u2022 ${m.displayName || m.user.username}`);
+
+        const embed = new EmbedBuilder()
+            .setTitle(`Rôle : ${role.name}`)
+            .addFields(
+                { name: 'Nom du rôle', value: `\u2022 ${role.name}`},
+                { name: 'Nombre de membres', value: `${members.length}`},
+                { name: 'Pseudo des membres', value: members.length > 0 ? members.join('\n') : 'Aucun membre.' },
+                { name: 'Date du rôle', value: `<t:${Math.floor(role.createdTimestamp / 1000)}:F>` }
+            )
+            .setColor(role.color || '#0099ff')
+            .setTimestamp();
+
+        await interaction.editReply({ embeds: [embed] });
+    }
+};

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,5 @@
+{
+  "commands": {
+    "listerole": true
+  }
+}


### PR DESCRIPTION
## Résumé
- ajout d'un fichier `listerole.js` dans `Commands`
- ce fichier permet d'afficher la liste des membres possédant un rôle
- ajoute un paramètre d'activation dans `settings.json`

## Tests
- Aucun test exécuté selon les instructions

------
https://chatgpt.com/codex/tasks/task_e_685cfd23203c8323b983a069d43de024