### PR TITLE
Supprime les messages Discord dont le post Reddit source est supprimé

### DIFF
--- a/Helpers/redditFashion.js
+++ b/Helpers/redditFashion.js
@@ -31,7 +31,17 @@ async function checkRedditFashion(client) {
       embed.setImage(post.preview.images[0].source.url.replace(/&amp;/g, '&'));
     }
 
-    await channel.send({ embeds: [embed] });
+    const message = await channel.send({ embeds: [embed] });
+
+    // Enregistre l'association message Discord / post Reddit
+    try {
+      await client.db.collection('redditPosts').doc(post.id).set({
+        messageId: message.id,
+        channelId: channel.id
+      });
+    } catch (saveErr) {
+      console.error('Erreur enregistrement Reddit:', saveErr);
+    }
   } catch (err) {
     console.error("Erreur Reddit:", err);
   }

--- a/Helpers/redditPostChecker.js
+++ b/Helpers/redditPostChecker.js
@@ -1,0 +1,34 @@
+const reddit = require('./redditAPI');
+
+async function checkRedditPosts(client) {
+  if (!client.db) return;
+  try {
+    const snapshot = await client.db.collection('redditPosts').get();
+    for (const doc of snapshot.docs) {
+      const postId = doc.id;
+      const { messageId, channelId } = doc.data();
+      try {
+        await reddit.getSubmission(postId).fetch();
+      } catch (err) {
+        if (err.statusCode === 404) {
+          const channel = client.channels.cache.get(channelId);
+          if (channel) {
+            try {
+              const message = await channel.messages.fetch(messageId);
+              await message.delete();
+            } catch (discordErr) {
+              console.error('Erreur suppression message Discord:', discordErr);
+            }
+          }
+          await client.db.collection('redditPosts').doc(postId).delete();
+        } else {
+          console.error('Erreur vérification post Reddit:', err);
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Erreur récupération redditPosts:', err);
+  }
+}
+
+module.exports = { checkRedditPosts };

--- a/bot.js
+++ b/bot.js
@@ -76,6 +76,7 @@ loadEvents(bot); // Load all commands in collection, to the bot
 // Configuration des flux RSS et des canaux
 const { checkRSS } = require('./Helpers/rssHandler');
 const { checkRedditFashion } = require('./Helpers/redditFashion');
+const { checkRedditPosts } = require('./Helpers/redditPostChecker');
 const RSS_FEEDS = [
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/news.xml' }, // Canal de maintenance
   { url: 'https://fr.finalfantasyxiv.com/lodestone/news/topics.xml' }  // Canal des annonces importantes
@@ -111,6 +112,7 @@ bot.on('ready', async () => {
     // Intervalles de vérification
     const redditFashionInterval = (bot.settings.redditFashionInterval || 60) * 60 * 1000;
     const rssInterval = (bot.settings.rssCheckInterval || 15) * 60 * 1000;
+    const redditPostCheckInterval = (bot.settings.redditPostCheckInterval || 60) * 60 * 1000;
     console.log(await dateFormatLog() + `Intervalle RSS configuré à ${rssInterval / 60000} min`);
 
     // Vérifier les différents flux RSS Lodestone et le best-of mensuel
@@ -134,9 +136,13 @@ bot.on('ready', async () => {
     // Vérification périodique du subreddit fashion
     if (bot.featureEnabled('redditFashion')) {
       checkRedditFashion(bot);
+      checkRedditPosts(bot);
       setInterval(() => {
         checkRedditFashion(bot);
       }, redditFashionInterval);
+      setInterval(() => {
+        checkRedditPosts(bot);
+      }, redditPostCheckInterval);
     }
   // Toutes les heures, on push le compteur de message sur Firestore
   setInterval(() => {

--- a/settings-dev.js
+++ b/settings-dev.js
@@ -12,6 +12,9 @@ module.exports = {
   // Intervalle de vérification du Reddit Fashion (en minutes)
   redditFashionInterval: 60,
 
+  // Intervalle de vérification des posts Reddit existants (en minutes)
+  redditPostCheckInterval: 60,
+
   // Durée maximale d'ancienneté des posts RSS (en heures)
   rssFreshnessHours: 24,
   

--- a/settings.js
+++ b/settings.js
@@ -12,6 +12,9 @@ module.exports = {
   // Intervalle de vérification du Reddit Fashion (en minutes)
   redditFashionInterval: 60,
 
+  // Intervalle de vérification des posts Reddit existants (en minutes)
+  redditPostCheckInterval: 60,
+
   // Durée maximale d'ancienneté des posts RSS (en heures)
   rssFreshnessHours: 24,
 


### PR DESCRIPTION
## Résumé
- Enregistre l'association entre messages Discord et posts Reddit.
- Vérifie périodiquement l'existence des posts Reddit et supprime les messages orphelins.
- Rend l'intervalle de vérification configurable.

## Test
- Aucun test exécuté à la demande du contributeur.

------
https://chatgpt.com/codex/tasks/task_e_688f86b271d48323be4dcb5444f765a6