### PR TITLE
Éviter la vérification redondante de redditFashion

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ features: {
   quoteSystem: true,
   rss: true,
   bestOfMonthly: true,
-  redditFashion: true,
   welcomeMessage: true,
   assignRoles: true,
   goodbyeMessage: true,
@@ -90,7 +89,6 @@ Passez une valeur à `false` pour désactiver la fonctionnalité correspondante 
 Certains délais peuvent être ajustés dans `settings.js` :
 
 ```js
-redditFashionInterval: 60 // Vérifie le subreddit Reddit Fashion toutes les 60 minutes
 rssFreshnessHours: 5     // Ignore les posts RSS plus vieux que 5 heures
 ```
 

--- a/bot.js
+++ b/bot.js
@@ -110,7 +110,7 @@ bot.on('ready', async () => {
   loadSlashCommands(bot);
 
     // Intervalles de vérification
-    const redditFashionInterval = (bot.settings.redditFashionInterval || 60) * 60 * 1000;
+    const redditFashionInterval = 60 * 60 * 1000; // 60 minutes
     const rssInterval = (bot.settings.rssCheckInterval || 15) * 60 * 1000;
     const redditPostCheckInterval = (bot.settings.redditPostCheckInterval || 60) * 60 * 1000;
     console.log(await dateFormatLog() + `Intervalle RSS configuré à ${rssInterval / 60000} min`);
@@ -124,9 +124,6 @@ bot.on('ready', async () => {
             checkRSS(bot, feed.url);
           });
         }
-        if (bot.featureEnabled('redditFashion')) {
-          checkRedditFashion(bot);
-        }
         if (bot.featureEnabled('comptMessage') && bot.featureEnabled('bestOfMonthly') && bot.featureEnabled('quoteSystem'))
         createMonthlyReport(bot);
         console.log(await dateFormatLog() + 'Fin de la vérification périodique des flux RSS');
@@ -134,12 +131,10 @@ bot.on('ready', async () => {
       }, rssInterval); // Vérification périodique des flux RSS
 
     // Vérification périodique du subreddit fashion
-    if (bot.featureEnabled('redditFashion')) {
+    checkRedditFashion(bot);
+    setInterval(() => {
       checkRedditFashion(bot);
-      setInterval(() => {
-        checkRedditFashion(bot);
-      }, redditFashionInterval);
-    }
+    }, redditFashionInterval);
 
     // Vérification périodique des posts Reddit pour suppressions éventuelles
     checkRedditPosts(bot);

--- a/settings-dev.js
+++ b/settings-dev.js
@@ -9,9 +9,6 @@ module.exports = {
   // Canal d'annonce au démarrage
   channelId: '000000000000000000',
 
-  // Intervalle de vérification du Reddit Fashion (en minutes)
-  redditFashionInterval: 60,
-
   // Intervalle de vérification des posts Reddit existants (en minutes)
   redditPostCheckInterval: 60,
 
@@ -82,7 +79,6 @@ module.exports = {
     quoteSystem: true, // Enregistre les citations et gère le best-of en fin de mois
     rss: true, // Vérifie les flux RSS Lodestone
     bestOfMonthly: true, // Génère le best-of mensuel
-    redditFashion: true, // Récupère les posts du subreddit fashion
     welcomeMessage: true, // Envoie un message de bienvenue aux nouveaux
     assignRoles: true, // Attribue les rôles de base lors de l'arrivée
     goodbyeMessage: true, // Indique quand un membre quitte le serveur

--- a/settings.js
+++ b/settings.js
@@ -9,9 +9,6 @@ module.exports = {
   // Canal d'annonce au démarrage
   channelId: '000000000000000000',
 
-  // Intervalle de vérification du Reddit Fashion (en minutes)
-  redditFashionInterval: 60,
-
   // Intervalle de vérification des posts Reddit existants (en minutes)
   redditPostCheckInterval: 60,
 
@@ -83,7 +80,6 @@ module.exports = {
     quoteSystem: true, // Enregistre les citations et gère le best-of en fin de mois
     rss: true, // Vérifie les flux RSS Lodestone
     bestOfMonthly: true, // Génère le best-of mensuel
-    redditFashion: true, // Récupère les posts du subreddit fashion
     welcomeMessage: true, // Envoie un message de bienvenue aux nouveaux
     assignRoles: true, // Attribue les rôles de base lors de l'arrivée
     goodbyeMessage: true, // Indique quand un membre quitte le serveur


### PR DESCRIPTION
## Résumé
- Supprime l'appel au check Reddit Fashion dans la boucle RSS
- Rend le check Reddit Fashion périodique via un intervalle fixe et retire la configuration associée
- Met à jour la documentation et les fichiers de paramètres

## Tests
- Aucun test exécuté

------
https://chatgpt.com/codex/tasks/task_e_6890a152f9e08323b2f5e79a2b27e34e