### PR TITLE
Ajout de l’horodatage dans les logs de debug

### DIFF
--- a/Helpers/logTools.js
+++ b/Helpers/logTools.js
@@ -1,20 +1,13 @@
 async function dateFormatLog() {
     const date = new Date();
 
-    // Décalage UTC+2
-    const offset = 2; // heures
-    const utc = date.getTime() + (date.getTimezoneOffset() * 60000);
-    const localDate = new Date(utc + (offset * 3600000));
-
-    let formattedDate = `${localDate.getDate().toString().padStart(2, '0')}/${(localDate.getMonth() + 1).toString().padStart(2, '0')}-${localDate.getHours().toString().padStart(2, '0')}h${localDate.getMinutes().toString().padStart(2, '0')}`;
-    formattedDate = `[${formattedDate}] `;
-
-    return formattedDate;
+    const formattedDate = `${date.getDate().toString().padStart(2, '0')}/${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getHours().toString().padStart(2, '0')}h${date.getMinutes().toString().padStart(2, '0')}`;
+    return `[${formattedDate}] `;
 }
 
-function debugLog(bot, feature, ...args) {
+async function debugLog(bot, feature, ...args) {
   if (bot?.settings?.debug?.[feature]) {
-    console.log(...args);
+    console.log(await dateFormatLog(), ...args);
   }
 }
 


### PR DESCRIPTION
## Résumé
- horodatage basé sur l'heure locale
- horodatage intégré aux logs de debug