### PR TITLE
Gestion des limites Reddit sans valeurs nulles

### DIFF
--- a/Helpers/redditRateLimit.js
+++ b/Helpers/redditRateLimit.js
@@ -1,0 +1,17 @@
+const config = require('../config/reddit.js');
+
+function getRateLimitInfo(reddit, rateLimit = config.rateLimit || 100, rateWindow = config.rateWindow || 600) {
+  const totalLimit = rateLimit * (rateWindow / 60);
+  const remaining = typeof reddit.ratelimitRemaining === 'number'
+    ? reddit.ratelimitRemaining
+    : totalLimit;
+  const used = typeof reddit.ratelimitUsed === 'number'
+    ? reddit.ratelimitUsed
+    : totalLimit - remaining;
+  const reset = typeof reddit.ratelimitExpiration === 'number'
+    ? Math.max(0, Math.ceil((reddit.ratelimitExpiration - Date.now()) / 1000))
+    : rateWindow;
+  return { used: Math.max(0, used), remaining: Math.max(0, remaining), reset };
+}
+
+module.exports = { getRateLimitInfo };

--- a/README.md
+++ b/README.md
@@ -87,20 +87,44 @@ Passez une valeur à `false` pour désactiver la fonctionnalité correspondante 
 
 ### Réglage des intervalles
 
-Certains délais peuvent être ajustés dans `settings.js` :
+Les paramètres liés à Reddit se trouvent dans `config/reddit.js` :
 
 ```js
-redditFashionInterval: 60 // Vérifie le subreddit Reddit Fashion toutes les 60 minutes
-redditRateLimit: 100      // Limite maximale de requêtes Reddit par minute (politique Reddit)
-redditUserAgent: 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)' // User-Agent conforme à l'API Reddit
-rssFreshnessHours: 5     // Ignore les posts RSS plus vieux que 5 heures
+module.exports = {
+  fashionInterval: 60, // Vérifie le subreddit Reddit Fashion toutes les 60 minutes
+  postCheckInterval: 60, // Vérifie les posts existants toutes les 60 minutes
+  rateLimit: 100,      // Limite maximale de requêtes Reddit par minute
+  rateReserve: 10,     // Arrêt quand il reste ce nombre de requêtes
+  rateWindow: 600,     // Fenêtre de ratelimit en secondes (10 min)
+  userAgent: 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)',
+  fashionChannelId: '000000000000000000',
+  debug: false,
+};
 ```
+
+Pour les flux RSS et autres réglages généraux, continuez d'utiliser `settings.js`.
 
 ### Mode debug Reddit
 
-Activez `debug.reddit` dans `settings.js` pour afficher les requêtes Reddit et les en-têtes de limitation d'API (`X-Ratelimit-Used`, `X-Ratelimit-Remaining`, `X-Ratelimit-Reset`).
+Activez `debug` dans `config/reddit.js` pour afficher les requêtes Reddit et les en-têtes de limitation d'API (`X-Ratelimit-Used`, `X-Ratelimit-Remaining`, `X-Ratelimit-Reset`).
 Les logs détaillent également le User-Agent, la limite configurée et le délai appliqué entre chaque requête.
 Ces messages, préfixés par `[Reddit]`, sont isolés du flux Lodestone afin d'éviter toute interférence.
+
+### Limites et conformité à l'API Reddit
+
+Reddit impose un maximum de **100 requêtes par minute et par identifiant OAuth**. Cette limite est calculée sur une fenêtre glissante d'environ **10 minutes**, soit jusqu'à 1 000 requêtes sur la période. Chaque réponse fournit les en‑têtes `X-Ratelimit-Used`, `X-Ratelimit-Remaining` et `X-Ratelimit-Reset` indiquant respectivement le nombre de requêtes utilisées, celles restantes et le temps avant réinitialisation. Le bot lit ces en‑têtes pour ajuster automatiquement son rythme.
+
+Les comptes bénéficiant d'un accès gratuit sont également soumis à des plafonds de **2 000 messages de chat par destinataire et 3 000 au total par jour**, ainsi qu'à une limite de **300 salons** rejointe quotidiennement. Le bot n'utilise pas l'API de messagerie et reste donc en‑dessous de ces seuils.
+
+Le fichier `config/reddit.js` permet de personnaliser cette politique :
+
+```js
+rateLimit: 100,  // Requêtes par minute
+rateWindow: 600, // Fenêtre de 10 minutes
+rateReserve: 10  // Seuil d'arrêt avant saturation
+```
+
+Des valeurs initiales sont définies au démarrage afin d'éviter tout affichage `null`, garantissant un suivi cohérent dès la première requête.
 
 ### Les commandes
 

--- a/bot.js
+++ b/bot.js
@@ -24,6 +24,7 @@ require('dotenv').config();
 
 const isDev = process.env.DEV_MODE === 'true';
 const botSettings = require(isDev ? './settings-dev.js' : './settings.js');
+const redditConfig = require('./config/reddit.js');
 
 const {dateFormatLog} = require('./Helpers/logTools');
 
@@ -58,6 +59,7 @@ console.log('Connexion validée !')
 
 bot.db = db
 bot.settings = botSettings
+bot.reddit = redditConfig
 
 // Fonction utilitaire pour savoir si une fonctionnalité est activée
 bot.featureEnabled = (name) => {
@@ -110,9 +112,9 @@ bot.on('ready', async () => {
   loadSlashCommands(bot);
 
     // Intervalles de vérification
-    const redditFashionInterval = (bot.settings.redditFashionInterval || 60) * 60 * 1000;
+    const redditFashionInterval = (bot.reddit.fashionInterval || 60) * 60 * 1000;
     const rssInterval = (bot.settings.rssCheckInterval || 15) * 60 * 1000;
-    const redditPostCheckInterval = (bot.settings.redditPostCheckInterval || 60) * 60 * 1000;
+    const redditPostCheckInterval = (bot.reddit.postCheckInterval || 60) * 60 * 1000;
     console.log(await dateFormatLog() + `Intervalle RSS configuré à ${rssInterval / 60000} min`);
 
     // Vérifier les différents flux RSS Lodestone et le best-of mensuel

--- a/config/reddit.js
+++ b/config/reddit.js
@@ -1,0 +1,25 @@
+module.exports = {
+  // Intervalle de vérification du Reddit Fashion (en minutes)
+  fashionInterval: 60,
+
+  // Intervalle de vérification des posts Reddit existants (en minutes)
+  postCheckInterval: 60,
+
+  // Limite de requêtes Reddit par minute (100 QPM maximum selon la politique Reddit)
+  rateLimit: 100,
+
+  // Marge de sécurité pour les requêtes Reddit (arrêt quand il reste ce nombre de requêtes)
+  rateReserve: 10,
+
+  // Durée de la fenêtre de ratelimit Reddit en secondes (politique actuelle : 10 minutes)
+  rateWindow: 600,
+
+  // User-Agent utilisé pour les requêtes Reddit
+  userAgent: 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)',
+
+  // Canal pour le flux Reddit Fashion
+  fashionChannelId: '000000000000000000',
+
+  // Logs de debug pour les interactions Reddit
+  debug: false,
+};

--- a/settings-dev.js
+++ b/settings-dev.js
@@ -9,21 +9,6 @@ module.exports = {
   // Canal d'annonce au démarrage
   channelId: '000000000000000000',
 
-  // Intervalle de vérification du Reddit Fashion (en minutes)
-  redditFashionInterval: 60,
-
-  // Intervalle de vérification des posts Reddit existants (en minutes)
-  redditPostCheckInterval: 60,
-
-  // Limite de requêtes Reddit par minute (100 QPM maximum selon la politique Reddit)
-  redditRateLimit: 100,
-
-  // Marge de sécurité pour les requêtes Reddit (arrêt quand il reste ce nombre de requêtes)
-  redditRateReserve: 10,
-
-  // User-Agent utilisé pour les requêtes Reddit
-  redditUserAgent: 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)',
-
   // Durée maximale d'ancienneté des posts RSS (en heures)
   rssFreshnessHours: 24,
   
@@ -39,8 +24,6 @@ module.exports = {
     goodbyeChannel: '000000000000000000',
     // Canal dédié au flux RSS Lodestone
     lodestoneRSSChannel: '000000000000000000',
-    // Canal pour le flux Reddit Fashion
-    redditFashionChannel: '000000000000000000',
     // Canal pour le best-of mensuel
     bestOfChannel: '000000000000000000',
     // Canal utilisé pour certaines notifications
@@ -100,7 +83,6 @@ module.exports = {
 
   // Configuration des logs de debug par fonctionnalité
   debug: {
-    reddit: true, // Logs pour les interactions Reddit
     rss: false,   // Logs pour le flux RSS
   },
 };

--- a/settings.js
+++ b/settings.js
@@ -9,21 +9,6 @@ module.exports = {
   // Canal d'annonce au démarrage
   channelId: '000000000000000000',
 
-  // Intervalle de vérification du Reddit Fashion (en minutes)
-  redditFashionInterval: 60,
-
-  // Intervalle de vérification des posts Reddit existants (en minutes)
-  redditPostCheckInterval: 60,
-
-  // Limite de requêtes Reddit par minute (100 QPM maximum selon la politique Reddit)
-  redditRateLimit: 100,
-
-  // Marge de sécurité pour les requêtes Reddit (arrêt quand il reste ce nombre de requêtes)
-  redditRateReserve: 10,
-
-  // User-Agent utilisé pour les requêtes Reddit
-  redditUserAgent: 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)',
-
   // Durée maximale d'ancienneté des posts RSS (en heures)
   rssFreshnessHours: 24,
 
@@ -40,8 +25,6 @@ module.exports = {
     goodbyeChannel: '000000000000000000',
     // Canal dédié au flux RSS Lodestone
     lodestoneRSSChannel: '000000000000000000',
-    // Canal pour le flux Reddit Fashion
-    redditFashionChannel: '000000000000000000',
     // Canal pour le best-of mensuel
     bestOfChannel: '000000000000000000',
     // Canal utilisé pour certaines notifications
@@ -101,7 +84,6 @@ module.exports = {
 
   // Configuration des logs de debug par fonctionnalité
   debug: {
-    reddit: false, // Logs pour les interactions Reddit
     rss: false,    // Logs pour le flux RSS
   },
 };


### PR DESCRIPTION
## Résumé
- Supprime la configuration `config/reddit-dev.js` et charge toujours `config/reddit.js`
- Calcule le quota global Reddit pour éviter les valeurs nulles ou négatives
- Les helpers Fashion et PostChecker utilisent la fenêtre de ratelimit configurée
- Documente les règles de l'API Reddit et la façon dont le bot les respecte