### PR TITLE
Sépare la configuration Reddit

### DIFF
--- a/Helpers/redditAPI.js
+++ b/Helpers/redditAPI.js
@@ -1,16 +1,18 @@
 const Snoowrap = require('snoowrap');
-const config = require('../config/reddit.js');
+const redditConfig = require('../config/reddit.js');
+const isDev = process.env.DEV_MODE === 'true';
+const appConfig = (require(isDev ? '../settings-dev.js' : '../settings.js').reddit) || {};
 
 const reddit = new Snoowrap({
-  userAgent: config.userAgent,
+  userAgent: redditConfig.userAgent,
   clientId: process.env.REDDIT_CLIENT_ID,
   clientSecret: process.env.REDDIT_CLIENT_SECRET,
   username: process.env.REDDIT_USERNAME,
   password: process.env.REDDIT_PASSWORD
 });
 
-const rateLimit = config.rateLimit || 100;
-const rateWindow = config.rateWindow || 600;
+const rateLimit = redditConfig.rateLimit || 100;
+const rateWindow = redditConfig.rateWindow || 600;
 const totalLimit = rateLimit * (rateWindow / 60);
 const requestDelay = Math.ceil(60000 / rateLimit);
 const logger = {
@@ -21,7 +23,7 @@ const logger = {
 reddit.config({
   requestDelay,
   continueAfterRatelimitError: true,
-  debug: !!config.debug,
+  debug: !!appConfig.debug,
   logger
 });
 
@@ -30,9 +32,9 @@ reddit.ratelimitRemaining = totalLimit;
 reddit.ratelimitUsed = 0;
 reddit.ratelimitExpiration = Date.now() + rateWindow * 1000;
 
-if (config.debug) {
+if (appConfig.debug) {
   console.log(
-    `[Reddit] Config - User-Agent: ${config.userAgent}, Limite: ${rateLimit} req/min, Fenêtre: ${rateWindow}s, Délai: ${requestDelay}ms`
+    `[Reddit] Config - User-Agent: ${redditConfig.userAgent}, Limite: ${rateLimit} req/min, Fenêtre: ${rateWindow}s, Délai: ${requestDelay}ms`
   );
 }
 

--- a/README.md
+++ b/README.md
@@ -88,34 +88,44 @@ Passez une valeur à `false` pour désactiver la fonctionnalité correspondante 
 
 ### Réglage des intervalles
 
-Les paramètres liés à Reddit se trouvent dans `config/reddit.js` :
+Les paramètres techniques liés à Reddit se trouvent dans `config/reddit.js` ; les autres options sont regroupées dans `settings.js` (ou `settings-dev.js`) sous la clé `reddit` :
 
 ```js
+// config/reddit.js
 const userAgent = 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)';
 
 module.exports = {
-  fashionInterval: 60, // Vérifie le subreddit Reddit Fashion toutes les 60 minutes
-  postCheckInterval: 60, // Vérifie les posts existants toutes les 60 minutes
   rateLimit: 100,      // Limite maximale de requêtes Reddit par minute
   rateReserve: 10,     // Arrêt quand il reste ce nombre de requêtes
   rateWindow: 600,     // Fenêtre de ratelimit en secondes (10 min)
   userAgent,           // User-Agent utilisé pour les requêtes Reddit
-  fashionSubreddit: 'ffxiv', // Subreddit ciblé
-  fashionQuery: 'author:Gottesstrafe Fashion Report - Full Details - For Week of', // Requête de recherche
-  fashionSort: 'new',  // Tri des résultats
-  fashionTime: 'week', // Période de recherche
-  fashionChannelId: '000000000000000000', // Canal pour le flux Fashion
-  debug: false,
+};
+```
+
+```js
+// settings.js
+module.exports = {
+  // ...
+  reddit: {
+    fashionInterval: 60, // Vérifie le subreddit Reddit Fashion toutes les 60 minutes
+    postCheckInterval: 60, // Vérifie les posts existants toutes les 60 minutes
+    fashionSubreddit: 'ffxiv', // Subreddit ciblé
+    fashionQuery: 'author:Gottesstrafe Fashion Report - Full Details - For Week of', // Requête de recherche
+    fashionSort: 'new',  // Tri des résultats
+    fashionTime: 'week', // Période de recherche
+    fashionChannelId: '000000000000000000', // Canal pour le flux Fashion
+    debug: false,
+  },
 };
 ```
 
 Le User-Agent est défini directement dans `config/reddit.js`.
 
-Pour les autres réglages généraux, continuez d'utiliser `settings.js`.
+Les autres réglages généraux restent dans `settings.js`.
 
 ### Mode debug Reddit
 
-Activez `debug` dans `config/reddit.js` pour afficher les requêtes Reddit et les en-têtes de limitation d'API (`X-Ratelimit-Used`, `X-Ratelimit-Remaining`, `X-Ratelimit-Reset`).
+Activez `debug` dans `settings.js` (ou `settings-dev.js`) à la section `reddit` pour afficher les requêtes Reddit et les en-têtes de limitation d'API (`X-Ratelimit-Used`, `X-Ratelimit-Remaining`, `X-Ratelimit-Reset`).
 Les logs détaillent également le User-Agent, la limite configurée et le délai appliqué entre chaque requête.
 Ces messages, préfixés par `[Reddit]`, sont isolés du flux Lodestone afin d'éviter toute interférence.
 

--- a/bot.js
+++ b/bot.js
@@ -24,7 +24,8 @@ require('dotenv').config();
 
 const isDev = process.env.DEV_MODE === 'true';
 const botSettings = require(isDev ? './settings-dev.js' : './settings.js');
-const redditConfig = require('./config/reddit.js');
+const redditTechnical = require('./config/reddit.js');
+const redditConfig = { ...redditTechnical, ...(botSettings.reddit || {}) };
 
 const {dateFormatLog} = require('./Helpers/logTools');
 

--- a/config/reddit.js
+++ b/config/reddit.js
@@ -1,12 +1,6 @@
 const userAgent = 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)';
 
 module.exports = {
-  // Intervalle de vérification du Reddit Fashion (en minutes)
-  fashionInterval: 60,
-
-  // Intervalle de vérification des posts Reddit existants (en minutes)
-  postCheckInterval: 60,
-
   // Limite de requêtes Reddit par minute (100 QPM maximum selon la politique Reddit)
   rateLimit: 100,
 
@@ -18,16 +12,4 @@ module.exports = {
 
   // User-Agent utilisé pour les requêtes Reddit
   userAgent,
-
-  // Paramètres de recherche pour le flux Fashion
-  fashionSubreddit: 'ffxiv',
-  fashionQuery: 'author:Gottesstrafe Fashion Report - Full Details - For Week of',
-  fashionSort: 'new',
-  fashionTime: 'week',
-
-  // Canal pour le flux Reddit Fashion
-  fashionChannelId: '000000000000000000',
-
-  // Logs de debug pour les interactions Reddit
-  debug: false,
 };

--- a/settings-dev.js
+++ b/settings-dev.js
@@ -79,6 +79,18 @@ module.exports = {
     comptMessage: true, // Compteur de message avec best-of en fin de mois
   },
 
+  // Paramètres généraux pour Reddit
+  reddit: {
+    fashionInterval: 60, // Vérifie le subreddit Reddit Fashion toutes les 60 minutes
+    postCheckInterval: 60, // Vérifie les posts existants toutes les 60 minutes
+    fashionSubreddit: 'ffxiv', // Subreddit ciblé
+    fashionQuery: 'author:Gottesstrafe Fashion Report - Full Details - For Week of', // Requête de recherche
+    fashionSort: 'new', // Tri des résultats
+    fashionTime: 'week', // Période de recherche
+    fashionChannelId: '000000000000000000', // Canal pour le flux Fashion
+    debug: false,
+  },
+
   // Configuration des logs de debug par fonctionnalité
   debug: {
     rss: false,   // Logs pour le flux RSS

--- a/settings.js
+++ b/settings.js
@@ -80,6 +80,18 @@ module.exports = {
     comptMessage: true, // Compteur de message avec best-of en fin de mois
   },
 
+  // Paramètres généraux pour Reddit
+  reddit: {
+    fashionInterval: 60, // Vérifie le subreddit Reddit Fashion toutes les 60 minutes
+    postCheckInterval: 60, // Vérifie les posts existants toutes les 60 minutes
+    fashionSubreddit: 'ffxiv', // Subreddit ciblé
+    fashionQuery: 'author:Gottesstrafe Fashion Report - Full Details - For Week of', // Requête de recherche
+    fashionSort: 'new', // Tri des résultats
+    fashionTime: 'week', // Période de recherche
+    fashionChannelId: '000000000000000000', // Canal pour le flux Fashion
+    debug: false,
+  },
+
   // Configuration des logs de debug par fonctionnalité
   debug: {
     rss: false,    // Logs pour le flux RSS


### PR DESCRIPTION
## Résumé
- déplace la configuration Reddit générale de `config/config.js` vers `settings.js` et `settings-dev.js`
- fusionne ces paramètres avec les réglages techniques dans `bot.js`
- adapte `Helpers/redditAPI.js` pour charger le debug depuis `settings.js`
- met à jour la documentation pour refléter l'emplacement des nouvelles options

## Tests
- aucun test effectué

------
https://chatgpt.com/codex/tasks/task_e_68920f030e588323ac71728af5c17c33