### PR TITLE
Gérer les erreurs 503 des flux RSS avec retries

### DIFF
--- a/settings-dev.js
+++ b/settings-dev.js
@@ -17,6 +17,9 @@ module.exports = {
 
   // User-Agent utilisé pour les requêtes RSS
   rssUserAgent: 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)',
+  // Gestion des tentatives de récupération du flux RSS
+  rssRetryAttempts: 3,
+  rssRetryDelay: 5000, // en millisecondes
   ids: {
     // Canal où sont envoyés les messages de bienvenue
     welcomeChannel: '000000000000000000',

--- a/settings.js
+++ b/settings.js
@@ -18,6 +18,10 @@ module.exports = {
   // User-Agent utilisé pour les requêtes RSS
   rssUserAgent: 'web:otter-management-bot:1.0.0 (by /u/OtterChantal-bot)',
 
+  // Gestion des tentatives de récupération du flux RSS
+  rssRetryAttempts: 3,
+  rssRetryDelay: 5000, // en millisecondes
+
   ids: {
     // Canal où sont envoyés les messages de bienvenue
     welcomeChannel: '000000000000000000',


### PR DESCRIPTION
## Résumé
- gère les réponses 503 lors de la récupération des flux RSS
- rend le nombre de tentatives et le délai entre essais configurables

## Test
- aucun test effectué

------
https://chatgpt.com/codex/tasks/task_e_6891d3a5c8388323a33c39eb18a3ffcd