### PR TITLE
feat: spoiler moderation command

### DIFF
--- a/Commands/spoiler.js
+++ b/Commands/spoiler.js
@@ -1,0 +1,63 @@
+const Discord = require('discord.js');
+
+module.exports = {
+    name: "spoiler",
+    description: "Remplace un message par une version masquée en cas de spoil.",
+    type: "MESSAGE",
+    dm: false,
+    permission: Discord.PermissionFlagsBits.ManageMessages,
+    async run(bot, interaction) {
+        if (!interaction.member.permissions.has(Discord.PermissionFlagsBits.ManageMessages)) {
+            return interaction.reply({ content: "Vous n'avez pas la permission d'utiliser cette commande.", ephemeral: true });
+        }
+
+        const targetMessage = interaction.targetMessage;
+        if (!targetMessage) {
+            return interaction.reply({ content: "Message introuvable.", ephemeral: true });
+        }
+
+        const content = targetMessage.content || "";
+        const author = targetMessage.author;
+
+        const files = targetMessage.attachments.map(att => {
+            const file = new Discord.AttachmentBuilder(att.url);
+            file.setSpoiler(true);
+            return file;
+        });
+
+        const modal = new Discord.ModalBuilder()
+            .setCustomId("spoiler-reason")
+            .setTitle("Raison de la censure (optionnel)");
+
+        const input = new Discord.TextInputBuilder()
+            .setCustomId("note")
+            .setLabel("Note")
+            .setStyle(Discord.TextInputStyle.Paragraph)
+            .setRequired(false);
+
+        const row = new Discord.ActionRowBuilder().addComponents(input);
+        modal.addComponents(row);
+
+        await interaction.showModal(modal);
+
+        try {
+            const submitted = await interaction.awaitModalSubmit({
+                time: 60_000,
+                filter: i => i.customId === "spoiler-reason" && i.user.id === interaction.user.id,
+            });
+
+            const note = submitted.fields.getTextInputValue("note")?.trim();
+            const maskedContent = content ? ` ||${content}||` : '';
+
+            await targetMessage.delete().catch(() => {});
+            await interaction.channel.send({
+                content: `Message de ${author}:${maskedContent}${note ? `\nRaison : ${note}` : ''}`,
+                files
+            });
+
+            await submitted.reply({ content: "Message masqué.", ephemeral: true });
+        } catch (e) {
+            await interaction.followUp({ content: "Commande annulée.", ephemeral: true }).catch(() => {});
+        }
+    }
+};

--- a/Loader/loadSlashCommands.js
+++ b/Loader/loadSlashCommands.js
@@ -15,44 +15,55 @@ module.exports = async bot => {
             return
         }
 
-        let slashCommand = new Discord.SlashCommandBuilder()
-        .setName(command.name)
-        .setDescription(command.description)
-        .setDMPermission(command.dm)
-        // Put permission "Aucune" if no permission is given.
-        .setDefaultMemberPermissions(command.permission === "Aucune" ? null : command.permission)
+        let slashCommand;
 
-        // Si on a des options.
-        if(command.options?.length >= 1) {
-            for(let i = 0; i < command.options.length; i++) {
+        if(command.type === "MESSAGE" || command.type === "USER") {
+            slashCommand = new Discord.ContextMenuCommandBuilder()
+            .setName(command.name)
+            .setType(command.type === "MESSAGE" ? Discord.ApplicationCommandType.Message : Discord.ApplicationCommandType.User)
+            .setDMPermission(command.dm)
+            .setDefaultMemberPermissions(command.permission === "Aucune" ? null : command.permission)
+        }
+        else{
+            slashCommand = new Discord.SlashCommandBuilder()
+            .setName(command.name)
+            .setDescription(command.description)
+            .setDMPermission(command.dm)
+            // Put permission "Aucune" if no permission is given.
+            .setDefaultMemberPermissions(command.permission === "Aucune" ? null : command.permission)
 
-                if(command.options[i].type === "SUB_COMMAND") {
-                    slashCommand.addSubcommand(subcommand => 
-                        subcommand.setName(command.options[i].name)
+            // Si on a des options.
+            if(command.options?.length >= 1) {
+                for(let i = 0; i < command.options.length; i++) {
+
+                    if(command.options[i].type === "SUB_COMMAND") {
+                        slashCommand.addSubcommand(subcommand =>
+                            subcommand.setName(command.options[i].name)
+                            .setDescription(command.options[i].description)
+                            // Ici, vous pouvez ajouter des options spécifiques à la sous-commande si nécessaire
+                        )
+                    }
+                    //If it's a string, add command
+                     else if(command.options[i].type === "STRING") {
+                        slashCommand[`add${command.options[i].type.charAt(0).toUpperCase()
+                            + command.options[i].type.slice(1).toLowerCase()}Option`]
+                        (optionBuilder =>
+                        optionBuilder.setName(command.options[i].name)
                         .setDescription(command.options[i].description)
-                        // Ici, vous pouvez ajouter des options spécifiques à la sous-commande si nécessaire
-                    )
-                }
-                //If it's a string, add command
-                 else if(command.options[i].type === "STRING") {
+                        .setAutocomplete(command.options[i].autocomplete)
+                        .setRequired(command.options[i].required))
+                    }
+                    else{
+                    // Put in the format capital letter for first caracter. Then put name, description and required.
                     slashCommand[`add${command.options[i].type.charAt(0).toUpperCase()
                         + command.options[i].type.slice(1).toLowerCase()}Option`]
-                    (optionBuilder => 
+                    (optionBuilder =>
                     optionBuilder.setName(command.options[i].name)
                     .setDescription(command.options[i].description)
-                    .setAutocomplete(command.options[i].autocomplete)
-                    .setRequired(command.options[i].required)) 
-                }
-                else{
-                // Put in the format capital letter for first caracter. Then put name, description and required.
-                slashCommand[`add${command.options[i].type.charAt(0).toUpperCase()
-                    + command.options[i].type.slice(1).toLowerCase()}Option`]
-                (optionBuilder => 
-                optionBuilder.setName(command.options[i].name)
-                .setDescription(command.options[i].description)
-                .setRequired(command.options[i].required))
-                }
+                    .setRequired(command.options[i].required))
+                    }
 
+                }
             }
         }
         await commands.push(slashCommand);


### PR DESCRIPTION
## Summary
- ajouter la commande de modération `spoiler`
- permettre au chargeur de commandes d'enregistrer les commandes contextuelles
- gérer les pièces jointes dans la commande `spoiler`
- permettre une note facultative dans la commande `spoiler`

## Testing
- aucun test effectué

------
https://chatgpt.com/codex/tasks/task_e_6892f7517f148323a207cb42e224176e