### PR TITLE
Renommer la commande spoiler en censurer, améliorer l'affichage et limiter la raison à 666 caractères

### DIFF
--- a/Commands/censurer.js
+++ b/Commands/censurer.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js');
 
 module.exports = {
-    name: "spoiler",
+    name: "censurer",
     description: "Remplace un message par une version masquée en cas de spoil.",
     type: "MESSAGE",
     dm: false,
@@ -18,6 +18,8 @@ module.exports = {
 
         const content = targetMessage.content || "";
         const author = targetMessage.author;
+        const member = targetMessage.member;
+        const pseudo = member ? member.displayName : author.username;
 
         const files = targetMessage.attachments.map(att => {
             const file = new Discord.AttachmentBuilder(att.url);
@@ -26,14 +28,15 @@ module.exports = {
         });
 
         const modal = new Discord.ModalBuilder()
-            .setCustomId("spoiler-reason")
+            .setCustomId("censurer-reason")
             .setTitle("Raison de la censure (optionnel)");
 
         const input = new Discord.TextInputBuilder()
             .setCustomId("note")
             .setLabel("Note")
             .setStyle(Discord.TextInputStyle.Paragraph)
-            .setRequired(false);
+            .setRequired(false)
+            .setMaxLength(666);
 
         const row = new Discord.ActionRowBuilder().addComponents(input);
         modal.addComponents(row);
@@ -43,19 +46,26 @@ module.exports = {
         try {
             const submitted = await interaction.awaitModalSubmit({
                 time: 60_000,
-                filter: i => i.customId === "spoiler-reason" && i.user.id === interaction.user.id,
+                filter: i => i.customId === "censurer-reason" && i.user.id === interaction.user.id,
             });
 
-            const note = submitted.fields.getTextInputValue("note")?.trim();
+            const note = submitted.fields.getTextInputValue("note")?.trim().slice(0, 666);
             const maskedContent = content ? ` ||${content}||` : '';
 
             await targetMessage.delete().catch(() => {});
-            await interaction.channel.send({
-                content: `Message de ${author}:${maskedContent}${note ? `\nRaison : ${note}` : ''}`,
-                files
-            });
 
-            await submitted.reply({ content: "Message masqué.", ephemeral: true });
+            const descriptionParts = [];
+            if (maskedContent) descriptionParts.push(maskedContent);
+            if (note) descriptionParts.push(`**Raison :** ${note}`);
+
+            const embed = new Discord.EmbedBuilder()
+                .setColor(0xff0000)
+                .setAuthor({ name: `Message de ${pseudo}`, iconURL: author.displayAvatarURL({ dynamic: true }) })
+                .setDescription(descriptionParts.join('\n\n'));
+
+            await interaction.channel.send({ embeds: [embed], files });
+
+            await submitted.reply({ content: "Message censuré.", ephemeral: true });
         } catch (e) {
             await interaction.followUp({ content: "Commande annulée.", ephemeral: true }).catch(() => {});
         }

--- a/Commands/censurer.js
+++ b/Commands/censurer.js
@@ -1,7 +1,7 @@
 const Discord = require('discord.js');
 
 module.exports = {
-    name: "censurer",
+    name: "Censurer",
     description: "Remplace un message par une version masquée en cas de spoil.",
     type: "MESSAGE",
     dm: false,


### PR DESCRIPTION
## Résumé
- renomme la commande contextuelle `spoiler` en `censurer`
- formate la réponse avec un embed pour afficher le message masqué et la raison
- limite la raison à 666 caractères
- affiche le pseudo serveur dans l'embed
- ajoute un filet rouge sur le côté gauche de l'embed